### PR TITLE
chore: rename vkt initialize call

### DIFF
--- a/src/main/scala/scalismo/vtk/initialize.scala
+++ b/src/main/scala/scalismo/vtk/initialize.scala
@@ -20,7 +20,7 @@ import vtk.vtkObjectBase
 
 import javax.swing.SwingUtilities
 
-object Initialize {
+object initialize {
   // this is a hacky way to get an object that can be synchronized on, with a mutable value.
   private val initialized = Array.fill(1)(false)
 

--- a/src/main/scala/scalismo/vtk/initialize.scala
+++ b/src/main/scala/scalismo/vtk/initialize.scala
@@ -1,4 +1,3 @@
-package scalismo.vtk
 /*
  * Copyright 2015 University of Basel, Graphics and Vision Research Group
  *
@@ -14,14 +13,14 @@ package scalismo.vtk
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package scalismo.vtk
 
 import ch.unibas.cs.gravis.vtkjavanativelibs.VtkNativeLibraries
 import vtk.vtkObjectBase
 
 import javax.swing.SwingUtilities
 
-package object initialize {
-
+object Initialize {
   // this is a hacky way to get an object that can be synchronized on, with a mutable value.
   private val initialized = Array.fill(1)(false)
 
@@ -34,7 +33,7 @@ package object initialize {
    *   time interval (in milliseconds) for running the vtk garbage collection. A value <= 0 means that garbage
    *   collection is not run automatically.
    */
-  def setup(ignoreErrors: Boolean = false, gcInterval: Long = 60 * 1000) = initialized.synchronized {
+  def apply(ignoreErrors: Boolean = false, gcInterval: Long = 60 * 1000) = initialized.synchronized {
     import java.io.File
     val nativeDir = new File(System.getProperty("user.home") + File.separator + ".scalismo")
     if (!initialized(0)) {
@@ -45,7 +44,6 @@ package object initialize {
       }
       initialized(0) = true
     }
-
   }
 
   private def setupVTKGCThread(gcInterval: Long): Unit = {
@@ -71,5 +69,4 @@ package object initialize {
     gcThread.setDaemon(true)
     gcThread.start()
   }
-
 }

--- a/src/main/scala/scalismo/vtk/initialize.scala
+++ b/src/main/scala/scalismo/vtk/initialize.scala
@@ -1,5 +1,4 @@
 package scalismo.vtk
-
 /*
  * Copyright 2015 University of Basel, Graphics and Vision Research Group
  *
@@ -21,7 +20,7 @@ import vtk.vtkObjectBase
 
 import javax.swing.SwingUtilities
 
-package object scalismo {
+package object initialize {
 
   // this is a hacky way to get an object that can be synchronized on, with a mutable value.
   private val initialized = Array.fill(1)(false)
@@ -35,7 +34,7 @@ package object scalismo {
    *   time interval (in milliseconds) for running the vtk garbage collection. A value <= 0 means that garbage
    *   collection is not run automatically.
    */
-  def initialize(ignoreErrors: Boolean = false, gcInterval: Long = 60 * 1000) = initialized.synchronized {
+  def setup(ignoreErrors: Boolean = false, gcInterval: Long = 60 * 1000) = initialized.synchronized {
     import java.io.File
     val nativeDir = new File(System.getProperty("user.home") + File.separator + ".scalismo")
     if (!initialized(0)) {

--- a/src/test/scala/scalismo/vtk/ScalismoTestSuite.scala
+++ b/src/test/scala/scalismo/vtk/ScalismoTestSuite.scala
@@ -3,5 +3,5 @@ package scalismo.vtk
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 class ScalismoTestSuite extends AnyFunSpec with Matchers {
-  scalismo.initialize()
+  scalismo.vtk.initialize.setup()
 }

--- a/src/test/scala/scalismo/vtk/ScalismoTestSuite.scala
+++ b/src/test/scala/scalismo/vtk/ScalismoTestSuite.scala
@@ -3,5 +3,5 @@ package scalismo.vtk
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 class ScalismoTestSuite extends AnyFunSpec with Matchers {
-  scalismo.vtk.Initialize()
+  scalismo.vtk.initialize()
 }

--- a/src/test/scala/scalismo/vtk/ScalismoTestSuite.scala
+++ b/src/test/scala/scalismo/vtk/ScalismoTestSuite.scala
@@ -3,5 +3,5 @@ package scalismo.vtk
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 class ScalismoTestSuite extends AnyFunSpec with Matchers {
-  scalismo.vtk.initialize.setup()
+  scalismo.vtk.Initialize()
 }

--- a/src/test/scala/scalismo/vtk/io/ImageIOTests.scala
+++ b/src/test/scala/scalismo/vtk/io/ImageIOTests.scala
@@ -79,8 +79,6 @@ class ImageIOTests extends ScalismoTestSuite {
         case Success(img) =>
           val doubles = img.data.map(v => implicitly[Scalar[T]].toDouble(v)).iterator.toArray
           (doubles.length, doubles.min, doubles.max) should equal((8, 42.0, 49.0))
-        // println("vtk " + typeOf[T] + " " + dim+ " " + img.data.getClass + " " + img.data.deep)
-
       }
       read should be a Symbol("Success")
 
@@ -95,7 +93,6 @@ class ImageIOTests extends ScalismoTestSuite {
         case Success(img) =>
           val doubles = img.data.map(v => implicitly[Scalar[T]].toDouble(v)).iterator.toArray
           (doubles.length, doubles.min, doubles.max) should equal((8, 42.0, 49.0))
-        // println("vtk " + typeOf[T] + " " + dim+ " " + img.data.getClass + " " + img.data.deep)
       }
       reread should be a Symbol("Success")
       vtk.delete()
@@ -111,7 +108,6 @@ class ImageIOTests extends ScalismoTestSuite {
           case Success(img) =>
             val doubles = img.data.map(v => implicitly[Scalar[T]].toDouble(v)).iterator.toArray
             (doubles.length, doubles.min, doubles.max) should equal((8, 42.0, 49.0))
-          // println("nii " + typeOf[T] + " " + dim+ " " + img.data.getClass + " " + img.data.deep)
         }
         nii.delete()
       }

--- a/src/test/scala/scalismo/vtk/registration/RegistrationTests.scala
+++ b/src/test/scala/scalismo/vtk/registration/RegistrationTests.scala
@@ -199,8 +199,6 @@ class RegistrationTests extends ScalismoTestSuite {
         LBFGSOptimizer(maxNumberOfIterations = 300)
       ).iterator(DenseVector.zeros[Double](transformationSpace.numberOfParameters))
       val regItPrinting = for (it <- regIt) yield {
-        println(it.value)
-        println(it.parameters)
         it
       }
 


### PR DESCRIPTION
Proposal to change the initialize call from `scalismo.vtk.scalismo.initialize()` to `scalismo.vtk.initialize.setup()`. 
I'm open for alternatives as well, one problem I found was the naming of the `vtk` module which is the same as the external vtk library that is used. So I had problems making a `scalismo.vtk.initialize()` call. 